### PR TITLE
Default to the first question

### DIFF
--- a/jemawa/cli.py
+++ b/jemawa/cli.py
@@ -65,6 +65,8 @@ def main():
             sys.exit(1)
 
     PRESENTER_QUESTION = INIT['questions'][0] # default
+    if not PRESENTER_ID:
+        PRESENTER_ID = PRESENTER_QUESTION['id']
     for question in INIT['questions']:
         if PRESENTER_ID == question['id']:
             if question['type'] not in SUPPORTED_TYPE:


### PR DESCRIPTION
Also added newline in the end of file.

Problem:
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\kitam\AppData\Local\Programs\Python\Python312\Scripts\jemawa.exe\__main__.py", line 7, in <module>
  File "C:\Users\kitam\AppData\Local\Programs\Python\Python312\Lib\site-packages\jemawa\cli.py", line 80, in main
    print(f"\nCurrent Presenter Page {QUESTIONS[PRESENTER_ID]['type']} {PRESENTER_ID} {PRESENTER_QUESTION['question']}\n")
                                      ~~~~~~~~~^^^^^^^^^^^^^^
KeyError: None

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
